### PR TITLE
修复使用 type C to HDMI hub 时，偶发内屏（4k）黑屏、花屏

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -194,6 +194,8 @@
 				<data>
 				AQAAAA==
 				</data>
+				<key>force-online-framebuffers</key>
+				<data>AAAAAAAAAAM=</data>
 				<key>framebuffer-con1-alldata</key>
 				<data>
 				AQUJAAAEAACHAQAA

--- a/OC/config.plist
+++ b/OC/config.plist
@@ -191,7 +191,9 @@
 				AQAAAA==
 				</data>
 				<key>force-online-framebuffers</key>
-				<data>AAAAAAAAAAM=</data>
+				<data>
+				AAAAAAAAAAM=
+				</data>
 				<key>framebuffer-con1-alldata</key>
 				<data>
 				AQUJAAAEAACHAQAA

--- a/OC/config.plist
+++ b/OC/config.plist
@@ -178,10 +178,6 @@
 				<data>
 				AQAAAA==
 				</data>
-				<key>enable-hdmi-dividers-fix</key>
-				<data>
-				AQAAAA==
-				</data>
 				<key>enable-hdmi20</key>
 				<data>
 				AQAAAA==


### PR DESCRIPTION
使用绿联 type C hub 的 HDMI 时，内屏偶发黑屏、花屏。
多出现在锁屏后开屏、睡眠唤醒时。
处理后问题暂未重现。