### PR TITLE
fix：4k@60Hz in BigSur

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -242,7 +242,11 @@
 				<data>
 				AQAAAA==
 				</data>
-				<key>enable-hdmi20</key>
+				<key>enable-max-pixel-clock-override</key>
+				<data>
+				AQAAAA==
+				</data>
+				<key>enable-backlight-registers-fix</key>
 				<data>
 				AQAAAA==
 				</data>


### PR DESCRIPTION
编译最新的的weg（见附件），可在BigSur下开启4k@60Hz的内屏显示，weg文档已更新相关内容。
在10.15.17和11.1下实测无问题，外接屏幕仅测试 TypeC - HDMI - 1080p,
[WhateverGreen.kext.zip](https://github.com/xxxzc/xps15-9570-macos/files/5712036/WhateverGreen.kext.zip)
